### PR TITLE
Fix memory leak in image viewer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,9 +17,21 @@ function App() {
 
   const xhrRef = useRef(null);
 
+  // Libera o objeto URL anterior quando a imagem muda
+  useEffect(() => {
+    return () => {
+      if (imagem) {
+        URL.revokeObjectURL(imagem);
+      }
+    };
+  }, [imagem]);
+
   const normalize = (str) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   const handleReset = () => {
+    if (imagem) {
+      URL.revokeObjectURL(imagem);
+    }
     setImagem(null);
     setResultado({});
     setFeedback({});

--- a/frontend/src/AppCS.jsx
+++ b/frontend/src/AppCS.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 function App() {
   const fileInputRef = useRef(null);
@@ -13,9 +13,21 @@ function App() {
   const [todosSelecionados, setTodosSelecionados] = useState(false);
   const [mensagemErroUI, setMensagemErroUI] = useState(""); // Novo estado para erros na UI
 
+  // Revoga o objeto URL antigo sempre que uma nova imagem é definida
+  useEffect(() => {
+    return () => {
+      if (imagem) {
+        URL.revokeObjectURL(imagem);
+      }
+    };
+  }, [imagem]);
+
   const normalize = (str) => str.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   const handleReset = () => {
+    if (imagem) {
+      URL.revokeObjectURL(imagem);
+    }
     setImagem(null);
     setResultado({});
     setFeedback({});


### PR DESCRIPTION
## Summary
- release previous image URLs in both React apps

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6f328cb88325a9ef50310cc7a4d6