### PR TITLE
Add frontend build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ uvicorn main:app --reload
 
 Then open: `http://127.0.0.1:8000/docs` to interact with the API using Swagger UI.
 
+## 💻 Frontend Setup
+
+Node.js and npm are required. Run the following commands:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+
 ## 📌 Update Notes
 
 ### Version 1.5.6 (UI + API)


### PR DESCRIPTION
## Summary
- add instructions for installing frontend dependencies and building the React UI

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_683f72a521cc8325a5c2abd985c3d122