### PR TITLE
Add localStorage persistence for history

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then open: `http://127.0.0.1:8000/docs` to interact with the API using Swagger U
 * [ ] 🖱️ Allow user to draw ROI (Region of Interest) manually on /docs interface.
 * [ ] 🌈 Improve support for noisy backgrounds and complex lighting.
 * [ ] 🤖 Train a ML model to further improve classification and segmentation.
-* [ ] 💾 Persistent local storage for historical analyses (e.g., using browser's localStorage).
+* [x] 💾 Persistent local storage for historical analyses (e.g., using browser's localStorage).
 * [ ] ⚙️ Consider making more image processing parameters (e.g., thresholds for area, circularity, max colony size factor) configurable via the API for advanced users.
 
 ---

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,30 @@ function App() {
 
   const xhrRef = useRef(null);
 
+  // Carrega histórico salvo no navegador ao inicializar
+  useEffect(() => {
+    try {
+      const salvo = localStorage.getItem('logAnalises');
+      if (salvo) {
+        const parsed = JSON.parse(salvo);
+        if (Array.isArray(parsed)) {
+          setLogAnalises(parsed);
+        }
+      }
+    } catch (e) {
+      console.error('Falha ao carregar histórico do localStorage', e);
+    }
+  }, []);
+
+  // Salva histórico sempre que sofrer alterações
+  useEffect(() => {
+    try {
+      localStorage.setItem('logAnalises', JSON.stringify(logAnalises));
+    } catch (e) {
+      console.error('Falha ao salvar histórico no localStorage', e);
+    }
+  }, [logAnalises]);
+
   // Libera o objeto URL anterior quando a imagem muda
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- store analysis history in browser localStorage
- mark the README task as done

## Testing
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f71fb451c8325a060c76ad573dac4