### PR TITLE
Fix memory leak in CSV export

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -191,9 +191,14 @@ function App() {
     });
     const blob = new Blob([linhas.join("\n")], { type: 'text/csv' });
     const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "analises_colonias.csv";
+    document.body.appendChild(link);
     link.click();
+    URL.revokeObjectURL(url);
+    // Remove o elemento para limpar a memória (opcional)
+    link.remove();
   };
 
   const excluirEntrada = (index) => {

--- a/frontend/src/AppCS.jsx
+++ b/frontend/src/AppCS.jsx
@@ -139,9 +139,14 @@ function App() {
     });
     const blob = new Blob([linhas.join("\n")], { type: 'text/csv' });
     const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
+    link.href = url;
     link.download = "analises_colonias.csv";
+    document.body.appendChild(link);
     link.click();
+    URL.revokeObjectURL(url);
+    // Remove o elemento para liberar memória (opcional)
+    link.remove();
   };
 
   const excluirEntrada = (index) => {


### PR DESCRIPTION
## Summary
- release object URLs and clean up temporary links after exporting CSVs in `App.jsx` and `AppCS.jsx`

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_683f72940948832598a403a78e187464