### PR TITLE
Add environment configuration and CSS classes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://bacteria-colony-counter-production.up.railway.app

--- a/README.md
+++ b/README.md
@@ -82,10 +82,18 @@ npm install
 npm run build
 ```
 
+Create a `.env` file in the project root defining the API base URL:
+
+```
+VITE_API_URL=https://bacteria-colony-counter-production.up.railway.app
+```
+
+The frontend reads this variable using `import.meta.env.VITE_API_URL` to send requests.
+
 
 ## 📌 Update Notes
 
-### Version 1.5.6 (UI + API)
+### Version 1.6.7 (UI + API)
 
 *Refined Calculation Logic: Significantly improved accuracy and robustness of density and total colony estimation by correcting and detailing the area extrapolation methodology.
 *Optimized Logging: Essential operational logs maintained for monitoring, while verbose debug logs have been cleaned up post-resolution of calculation issues.

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(
     title="API de Contagem de Colônias",
     description="Processa imagens de placas de Petri para contar e classificar colônias.",
-    version="1.6.6"  # Versão limpa pós-depuração
+    version="1.6.7"  # Versão limpa pós-depuração
 )
 
 ALLOWED_ORIGINS = [

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,8 @@ import ProgressBar from './components/ProgressBar';
 import ResultSection from './components/ResultSection';
 import HistorySection from './components/HistorySection';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 function App() {
   const fileInputRef = useRef(null);
   const [imagem, setImagem] = useState(null);
@@ -188,7 +190,7 @@ function App() {
     };
 
 
-    xhr.open('POST', 'https://bacteria-colony-counter-production.up.railway.app/contar/', true);
+    xhr.open('POST', `${API_URL}/contar/`, true);
     xhr.responseType = 'blob';
     xhr.send(formData);
   };
@@ -263,9 +265,9 @@ function App() {
 
 
   return (
-    <div style={{ padding: 20, textAlign: 'center', backgroundColor: '#111', color: '#fff', minHeight: '100vh' }}>
-      <h1 style={{ fontSize: 32 }}>Contador de Colônias Bacterianas v1.6.6 (Alta Densidade)</h1>
-      <p style={{ backgroundColor: '#222', color: '#ddd', padding: '10px 15px', borderRadius: 8, maxWidth: 600, margin: '10px auto', fontSize: 14 }}>
+    <div className="app-container">
+      <h1 className="app-header">Contador de Colônias Bacterianas v1.6.6 (Alta Densidade)</h1>
+      <p className="caution-msg">
         ⚠️ Esta versão é otimizada para imagens com <strong>grande número de colônias(&gt;300 UFC/placa)</strong>.
         Pode gerar falsos positivos em placas com baixa densidade ou interferências no fundo.
       </p>
@@ -310,7 +312,7 @@ function App() {
         processando={processando}
       />
 
-      <footer style={{ marginTop: 40, fontSize: 14, opacity: 0.6 }}>
+      <footer className="footer-info">
         👨‍🔬 Powered by <strong>Daniel Borges</strong>
       </footer>
       </div>

--- a/frontend/src/components/HistorySection.jsx
+++ b/frontend/src/components/HistorySection.jsx
@@ -1,16 +1,5 @@
 import React from 'react';
 
-const botaoEstilo = {
-  backgroundColor: '#000',
-  color: '#fff',
-  border: '1px solid #fff',
-  padding: '10px 18px',
-  margin: '5px',
-  borderRadius: 8,
-  cursor: 'pointer',
-  fontWeight: 'bold',
-};
-
 function HistorySection({
   logAnalises,
   selecionados,
@@ -25,18 +14,18 @@ function HistorySection({
   if (logAnalises.length === 0) return null;
 
   return (
-    <div style={{ marginTop: 30 }}>
+    <div className="history-container">
       <h3>📋 Histórico de Análises</h3>
-      <div style={{ marginBottom: 10 }}>
-        <button onClick={selecionarTodos} style={botaoEstilo} disabled={processando}>
+      <div className="history-actions">
+        <button onClick={selecionarTodos} className="btn" disabled={processando}>
           {todosSelecionados ? '☑️ Desmarcar Todos' : '✅ Selecionar Todos'}
         </button>
-        <button onClick={exportarCSV} style={botaoEstilo} disabled={processando}>⬇️ Exportar Selecionados</button>
-        <button onClick={excluirTodos} style={botaoEstilo} disabled={processando}>🗑️ Excluir Tudo</button>
+        <button onClick={exportarCSV} className="btn" disabled={processando}>⬇️ Exportar Selecionados</button>
+        <button onClick={excluirTodos} className="btn" disabled={processando}>🗑️ Excluir Tudo</button>
       </div>
-      <table style={{ width: '100%', marginTop: 10, borderCollapse: 'collapse', fontSize: 13 }}>
+      <table className="history-table">
         <thead>
-          <tr style={{ backgroundColor: '#222', color: '#ddd' }}>
+          <tr>
             <th><input type="checkbox" onChange={selecionarTodos} checked={todosSelecionados} disabled={processando} /></th>
             <th>Data</th>
             <th>Hora</th>
@@ -49,7 +38,7 @@ function HistorySection({
         </thead>
         <tbody>
           {logAnalises.map((item, idx) => (
-            <tr key={idx} style={{ backgroundColor: idx % 2 === 0 ? '#1c1c1c' : '#2c2c2c' }}>
+            <tr key={idx} className={idx % 2 === 0 ? 'row-even' : 'row-odd'}>
               <td><input type="checkbox" checked={!!selecionados[idx]} onChange={() => toggleSelecionado(idx)} disabled={processando} /></td>
               <td>{item.data}</td>
               <td>{item.hora}</td>
@@ -57,7 +46,7 @@ function HistorySection({
               <td>{item.TOTAL}</td>
               <td>{item.densidadecoloniascm2}</td>
               <td>{item.estimativatotalcolonias}</td>
-              <td><button onClick={() => excluirEntrada(idx)} style={{ fontSize: 11, backgroundColor: '#800', color: '#fff', border: 'none', padding: '4px 8px', borderRadius: 4, cursor: 'pointer' }} disabled={processando}>Excluir</button></td>
+              <td><button onClick={() => excluirEntrada(idx)} className="delete-btn" disabled={processando}>Excluir</button></td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/ProgressBar.jsx
+++ b/frontend/src/components/ProgressBar.jsx
@@ -1,61 +1,27 @@
 import React from 'react';
 
-const botaoEstilo = {
-  backgroundColor: '#000',
-  color: '#fff',
-  border: '1px solid #fff',
-  padding: '10px 18px',
-  margin: '5px',
-  borderRadius: 8,
-  cursor: 'pointer',
-  fontWeight: 'bold',
-};
-
 function ProgressBar({ processando, statusMensagem, uploadProgress, onCancel }) {
   if (!processando) return null;
 
   return (
-    <div style={{ marginTop: 20, padding: 15, backgroundColor: 'rgba(50,50,50,0.8)', borderRadius: 8, maxWidth: 400, margin: '10px auto' }}>
-      <p style={{fontSize: 16, fontWeight: 'bold', marginBottom: 10}}>{statusMensagem}</p>
+    <div className="progress-container">
+      <p className="status-message">{statusMensagem}</p>
       {uploadProgress > 0 && uploadProgress < 100 && (
-        <div style={{ width: '100%', backgroundColor: '#555', borderRadius: 4, overflow: 'hidden', border: '1px solid #777', marginBottom: 10 }}>
+        <div className="progress-bar-wrapper">
           <div
-            style={{
-              width: `${uploadProgress}%`,
-              height: '20px',
-              backgroundColor: '#4caf50',
-              textAlign: 'center',
-              lineHeight: '20px',
-              color: 'white',
-              transition: 'width 0.3s ease-in-out'
-            }}
+            className="progress-bar"
+            style={{ width: `${uploadProgress}%` }}
           >
             {uploadProgress}%
           </div>
         </div>
       )}
       {uploadProgress === 100 && statusMensagem.includes('Aguarde, processando') && (
-        <div style={{ width: '100%', backgroundColor: '#555', borderRadius: 4, overflow: 'hidden', border: '1px solid #777', marginBottom: 10 }}>
-          <div
-            style={{
-              width: '100%',
-              height: '20px',
-              backgroundColor: '#2a782c',
-              textAlign: 'center',
-              lineHeight: '20px',
-              color: 'white'
-            }}
-          >
-            Enviado!
-          </div>
+        <div className="progress-bar-wrapper">
+          <div className="progress-bar progress-complete">Enviado!</div>
         </div>
       )}
-      <button
-        onClick={onCancel}
-        style={{...botaoEstilo, backgroundColor: '#c00', padding: '8px 15px', fontSize: '0.9em'}}
-      >
-        Cancelar
-      </button>
+      <button onClick={onCancel} className="btn btn-danger">Cancelar</button>
     </div>
   );
 }

--- a/frontend/src/components/ResultSection.jsx
+++ b/frontend/src/components/ResultSection.jsx
@@ -1,16 +1,5 @@
 import React from 'react';
 
-const botaoEstilo = {
-  backgroundColor: '#000',
-  color: '#fff',
-  border: '1px solid #fff',
-  padding: '10px 18px',
-  margin: '5px',
-  borderRadius: 8,
-  cursor: 'pointer',
-  fontWeight: 'bold',
-};
-
 function ResultSection({ imagem, processando, resultado, feedback, onBaixar, onReset }) {
   if (!imagem) return null;
 
@@ -19,34 +8,34 @@ function ResultSection({ imagem, processando, resultado, feedback, onBaixar, onR
   const estimativa = feedback["estimativatotalcolonias"] || 0;
 
   return (
-    <div style={{ marginTop: 20 }}>
-      <img src={imagem} alt="Resultado do Processamento" style={{ maxWidth: 500, width: '100%', borderRadius: 10 }} />
+    <div className="result-section">
+      <img src={imagem} alt="Resultado do Processamento" className="result-image" />
 
       {!processando && Object.keys(resultado).length > 0 && !resultado.ERRO && (
-        <div style={{ marginTop: 15 }}>
+        <div className="summary-container">
           <h3>🧪 Resumo de Colônias</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <span style={{ color: '#fff', marginBottom: 4 }}><strong>TOTAL:</strong> {total}</span>
-            <span style={{ color: '#fff', marginBottom: 4 }}><strong>Densidade (UFC/cm2):</strong> {densidade}</span>
-            <span style={{ color: '#fff', marginBottom: 4 }}><strong>Estimativa Total (Placa 57.5cm2):</strong> {estimativa}</span>
+          <div className="summary-content">
+            <span className="summary-row"><strong>TOTAL:</strong> {total}</span>
+            <span className="summary-row"><strong>Densidade (UFC/cm2):</strong> {densidade}</span>
+            <span className="summary-row"><strong>Estimativa Total (Placa 57.5cm2):</strong> {estimativa}</span>
           </div>
           {Object.keys(feedback).length > 0 && (
-            <div style={{ marginTop: 20 }}>
+            <div className="details-container">
               <h4>⚙️ Detalhes Técnicos</h4>
-              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+              <div className="details-content">
                 {Object.entries(feedback).map(([chave, valor]) => (
                   !["densidadecoloniascm2", "estimativatotalcolonias"].includes(chave) && (
-                    <span key={chave} style={{ color: '#ccc', fontSize: 13, marginBottom: 3 }}><strong>{chave}:</strong> {valor}</span>
+                    <span key={chave} className="details-item"><strong>{chave}:</strong> {valor}</span>
                   )
                 ))}
               </div>
             </div>
           )}
-          <div style={{ marginTop: 10 }}>
-            <button onClick={onBaixar} style={botaoEstilo} disabled={processando}>
+          <div className="buttons-container">
+            <button onClick={onBaixar} className="btn" disabled={processando}>
               📥 Baixar Resultado
             </button>
-            <button onClick={onReset} style={botaoEstilo} disabled={processando}>
+            <button onClick={onReset} className="btn" disabled={processando}>
               ♻️ Nova Imagem
             </button>
           </div>

--- a/frontend/src/components/UploadSection.jsx
+++ b/frontend/src/components/UploadSection.jsx
@@ -1,29 +1,5 @@
 import React from 'react';
 
-const botaoEstilo = {
-  backgroundColor: '#000',
-  color: '#fff',
-  border: '1px solid #fff',
-  padding: '10px 18px',
-  margin: '5px',
-  borderRadius: 8,
-  cursor: 'pointer',
-  fontWeight: 'bold',
-};
-
-const errorStyle = {
-  color: 'white',
-  marginTop: 15,
-  marginBottom: 10,
-  padding: '10px 15px',
-  border: '1px solid #ff4d4d',
-  borderRadius: 8,
-  backgroundColor: '#6b2222',
-  maxWidth: 600,
-  margin: '10px auto',
-  fontSize: 14,
-};
-
 function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAmostra, processando, mensagemErroUI }) {
   return (
     <>
@@ -38,15 +14,15 @@ function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAm
 
       <input
         type="text"
+        className="text-input"
         placeholder="Nome da Amostra"
         value={nomeAmostra}
         onChange={e => setNomeAmostra(e.target.value)}
-        style={{ padding: 8, marginTop: 10, borderRadius: 6, border: '1px solid #444', backgroundColor: '#222', color: '#fff' }}
         disabled={processando}
       /><br />
 
       {mensagemErroUI && (
-        <div style={errorStyle}>
+        <div className="error-message">
           <strong>Erro:</strong> {mensagemErroUI}
         </div>
       )}
@@ -54,7 +30,7 @@ function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAm
       {!processando && (
         <button
           onClick={() => fileInputRef.current?.click()}
-          style={botaoEstilo}
+          className="btn"
           disabled={processando}
         >
           📤 Enviar Imagem

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,3 +66,192 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+/* Custom classes */
+.app-container {
+  padding: 20px;
+  text-align: center;
+  background-color: #111;
+  color: #fff;
+  min-height: 100vh;
+}
+
+.app-header {
+  font-size: 32px;
+}
+
+.caution-msg {
+  background-color: #222;
+  color: #ddd;
+  padding: 10px 15px;
+  border-radius: 8px;
+  max-width: 600px;
+  margin: 10px auto;
+  font-size: 14px;
+}
+
+.btn {
+  background-color: #000;
+  color: #fff;
+  border: 1px solid #fff;
+  padding: 10px 18px;
+  margin: 5px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.btn-danger {
+  background-color: #c00;
+  padding: 8px 15px;
+  font-size: 0.9em;
+}
+
+.text-input {
+  padding: 8px;
+  margin-top: 10px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  background-color: #222;
+  color: #fff;
+}
+
+.error-message {
+  color: white;
+  margin-top: 15px;
+  margin-bottom: 10px;
+  padding: 10px 15px;
+  border: 1px solid #ff4d4d;
+  border-radius: 8px;
+  background-color: #6b2222;
+  max-width: 600px;
+  margin: 10px auto;
+  font-size: 14px;
+}
+
+.progress-container {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: rgba(50, 50, 50, 0.8);
+  border-radius: 8px;
+  max-width: 400px;
+  margin: 10px auto;
+}
+
+.status-message {
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.progress-bar-wrapper {
+  width: 100%;
+  background-color: #555;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid #777;
+  margin-bottom: 10px;
+}
+
+.progress-bar {
+  height: 20px;
+  text-align: center;
+  line-height: 20px;
+  color: white;
+  transition: width 0.3s ease-in-out;
+  background-color: #4caf50;
+}
+
+.progress-complete {
+  width: 100%;
+  background-color: #2a782c;
+}
+
+.result-section {
+  margin-top: 20px;
+}
+
+.result-image {
+  max-width: 500px;
+  width: 100%;
+  border-radius: 10px;
+}
+
+.summary-container {
+  margin-top: 15px;
+}
+
+.summary-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.summary-row {
+  color: #fff;
+  margin-bottom: 4px;
+}
+
+.details-container {
+  margin-top: 20px;
+}
+
+.details-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.details-item {
+  color: #ccc;
+  font-size: 13px;
+  margin-bottom: 3px;
+}
+
+.buttons-container {
+  margin-top: 10px;
+}
+
+.history-container {
+  margin-top: 30px;
+}
+
+.history-actions {
+  margin-bottom: 10px;
+}
+
+.history-table {
+  width: 100%;
+  margin-top: 10px;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.history-table thead tr {
+  background-color: #222;
+  color: #ddd;
+}
+
+.row-even {
+  background-color: #1c1c1c;
+}
+
+.row-odd {
+  background-color: #2c2c2c;
+}
+
+.delete-btn {
+  font-size: 11px;
+  background-color: #800;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.footer-info {
+  margin-top: 40px;
+  font-size: 14px;
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` in the frontend and document it
- update API version to 1.6.7
- move inline styles to CSS classes
- provide `.env.example` with API url

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f81c79a508325a6a0c25f9ecdde10