### PR TITLE
Corrige referência a arquivo inexistente

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ The frontend reads this variable using `import.meta.env.VITE_API_URL` to send re
 The repository provides a helper script at `scripts/bump_version.py` to keep the
 API and frontend versions in sync. Running the script increments the version in
 `frontend/package.json`, updates the `version` argument of the `FastAPI()`
-instances in `backend/main.py` and `backend/mainCS.py`, and commits the changes
-with the message `Bump version`.
+instance in `backend/main.py`, and commits the changes with the message
+`Bump version`.
 
 Run it manually whenever you need to bump the version:
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -18,13 +18,12 @@ def bump_version():
     data['version'] = new_version
     pkg_path.write_text(json.dumps(data, indent=2) + '\n')
 
-    for backend_file in ['backend/main.py', 'backend/mainCS.py']:
-        path = Path(backend_file)
-        text = path.read_text()
-        text = re.sub(r'version="[0-9.]+"', f'version="{new_version}"', text)
-        path.write_text(text)
+    backend_file = Path('backend/main.py')
+    text = backend_file.read_text()
+    text = re.sub(r'version="[0-9.]+"', f'version="{new_version}"', text)
+    backend_file.write_text(text)
 
-    subprocess.run(['git', 'add', 'frontend/package.json', 'backend/main.py', 'backend/mainCS.py'], check=True)
+    subprocess.run(['git', 'add', 'frontend/package.json', 'backend/main.py'], check=True)
     subprocess.run(['git', 'commit', '--no-verify', '-m', 'Bump version'], check=True)
 
 


### PR DESCRIPTION
## Notas
- Não há suíte de testes.

## Summary
- Corrige `scripts/bump_version.py` para atualizar apenas `backend/main.py`
- Ajusta README removendo menção ao arquivo inexistente `backend/mainCS.py`

## Testing
- `python -m py_compile backend/main.py scripts/bump_version.py`

------
https://chatgpt.com/codex/tasks/task_e_683f84cabf7483258f36ea024cb7ba0e