### PR TITLE
Handle missing API URL

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -96,6 +96,13 @@ function App() {
     const xhr = new XMLHttpRequest();
     xhrRef.current = xhr;
 
+    if (!API_URL) {
+      setMensagemErroUI("URL da API não definida. Verifique o arquivo .env (VITE_API_URL).");
+      setProcessando(false);
+      setUploadProgress(0);
+      return;
+    }
+
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable) {
         const percentComplete = Math.round((e.loaded / e.total) * 100);


### PR DESCRIPTION
## Summary
- improve error messaging for missing VITE_API_URL in the frontend

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f8760aca48325894ac60dec25dcd5