### PR TITLE
Add drag-and-drop preview upload

### DIFF
--- a/frontend/src/components/UploadSection.jsx
+++ b/frontend/src/components/UploadSection.jsx
@@ -1,13 +1,35 @@
 import React from 'react';
 
 function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAmostra, processando, mensagemErroUI }) {
+  const [previewSrc, setPreviewSrc] = React.useState(null);
+
+  const previewAndUpload = (files) => {
+    const file = files && files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setPreviewSrc(e.target.result);
+      handleImageUpload({ target: { files } });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleFileSelect = (e) => {
+    previewAndUpload(e.target.files);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    previewAndUpload(e.dataTransfer.files);
+  };
+
   return (
     <>
       <input
         type="file"
         accept="image/*"
         ref={fileInputRef}
-        onChange={handleImageUpload}
+        onChange={handleFileSelect}
         style={{ display: 'none' }}
         disabled={processando}
       />
@@ -20,6 +42,21 @@ function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAm
         onChange={e => setNomeAmostra(e.target.value)}
         disabled={processando}
       /><br />
+
+      <div
+        className="drop-area"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        Arraste e solte a imagem aqui ou clique para selecionar
+      </div>
+
+      {previewSrc && (
+        <div className="preview-container">
+          <img src={previewSrc} alt="Pré-visualização" className="preview-image" />
+        </div>
+      )}
 
       {mensagemErroUI && (
         <div className="error-message">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -255,3 +255,21 @@ button:focus-visible {
   font-size: 14px;
   opacity: 0.6;
 }
+
+.drop-area {
+  border: 2px dashed #444;
+  padding: 20px;
+  margin: 10px auto;
+  border-radius: 8px;
+  max-width: 300px;
+  cursor: pointer;
+}
+
+.preview-container {
+  margin-top: 10px;
+}
+
+.preview-image {
+  max-width: 150px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- allow drag-and-drop image selection in UploadSection
- show preview before uploading
- style drop area and preview image

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9704f0b08325aef46af4a639a2a1