### PR TITLE
Add color model training and inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This FastAPI-based application processes images of Petri dishes to count and cla
 
 * Automatic detection of Petri dish using Hough Circle Transform.
 * Manual override for dish coordinates and radius (x, y, r).
-* Classification of colonies based on color in HSV space.
+* Classification of colonies using a trained color model (fallback to HSV rules).
 * Advanced filtering by area, circularity, and maximum relative size to improve accuracy.
 * Visualization output with colored circles indicating colony classification.
 * 🔽 Download processed image with one click.
@@ -61,8 +61,19 @@ This FastAPI-based application processes images of Petri dishes to count and cla
 ## 📦 Requirements
 
 ```bash
-pip install fastapi uvicorn opencv-python-headless numpy scipy python-multipart pandas
+pip install fastapi uvicorn opencv-python-headless numpy scipy python-multipart pandas scikit-learn joblib
 ```
+
+## 🏋️ Treinar Modelo de Cor
+
+Forneça um CSV com as colunas `h`, `s`, `v` e `label` (uma das quatro cores).
+Execute:
+
+```bash
+python scripts/train_color_model.py dados.csv backend/color_model.pkl
+```
+
+O arquivo `color_model.pkl` será carregado automaticamente pelo backend.
 
 ## 🛠️ Run Locally
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ numpy
 scipy
 python-multipart
 pandas
+scikit-learn
+joblib

--- a/scripts/train_color_model.py
+++ b/scripts/train_color_model.py
@@ -1,0 +1,25 @@
+import argparse
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+import joblib
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Treina modelo de classificação de cor")
+    parser.add_argument("csv", help="Arquivo CSV com colunas h,s,v,label")
+    parser.add_argument("saida", help="Arquivo para salvar o modelo treinado")
+    args = parser.parse_args()
+
+    dados = pd.read_csv(args.csv)
+    X = dados[["h", "s", "v"]]
+    y = dados["label"]
+
+    clf = RandomForestClassifier(n_estimators=200, random_state=42)
+    clf.fit(X, y)
+
+    joblib.dump(clf, args.saida)
+    print(f"Modelo salvo em {args.saida}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts/train_color_model.py` to train a RandomForest color classifier
- load optional `color_model.pkl` in backend and predict colony color
- fall back to HSV rules when model isn't available
- document training usage and update requirements

## Testing
- `python -m py_compile scripts/train_color_model.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa812858c8325acc7eeed917dcc70