### PR TITLE
Add tooltips and ROI hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This FastAPI-based application processes images of Petri dishes to count and cla
 
 * Automatic detection of Petri dish using Hough Circle Transform.
 * Manual override for dish coordinates and radius (x, y, r).
+* Optional advanced mode with on-image drawing to set manual center/radius and fine-tune filters.
+* Dica: para definir manualmente a ROI, clique no centro da placa e arraste até a borda.
 * Classification of colonies using a trained color model (fallback to HSV rules).
 * Advanced filtering by area, circularity, and maximum relative size to improve accuracy.
 * Visualization output with colored circles indicating colony classification.
@@ -36,6 +38,10 @@ This FastAPI-based application processes images of Petri dishes to count and cla
 * `x` (form-data, optional): X-coordinate of the plate center (pixels in the original image). Auto-detected if not provided.
 * `y` (form-data, optional): Y-coordinate of the plate center (pixels in the original image). Auto-detected if not provided.
 * `r` (form-data, optional): Radius of the plate (pixels in the original image). Auto-detected if not provided.
+* `area_min` (form-data, optional): Minimum colony area in pixels. Default `4.0`.
+* `circularidade_min` (form-data, optional): Minimum circularity. Default `0.30`.
+* `max_colony_size_factor` (form-data, optional): Max relative radius of a colony compared to the plate margin. Default `0.2`.
+  Use esses parâmetros para refinar a contagem em "Análise Avançada".
 
 **Response:**
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contador-colonias",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,8 +78,7 @@ function App() {
     setUploadResetSignal((c) => c + 1);
   };
 
-  const handleImageUpload = async (event) => {
-    const file = event.target.files[0];
+  const handleImageUpload = async (file, extras = {}) => {
     if (!file) return;
 
     setProcessando(true);
@@ -94,6 +93,11 @@ function App() {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('nome_amostra', nomeAmostra || file.name);
+    Object.entries(extras).forEach(([chave, valor]) => {
+      if (valor !== undefined && valor !== null && valor !== '') {
+        formData.append(chave, valor);
+      }
+    });
 
     const xhr = new XMLHttpRequest();
     xhrRef.current = xhr;
@@ -275,7 +279,7 @@ function App() {
 
   return (
     <div className="app-container">
-      <h1 className="app-header">Contador de Colônias Bacterianas v1.0.1 (Alta Densidade)</h1>
+      <h1 className="app-header">Contador de Colônias Bacterianas v1.0.3 (Alta Densidade)</h1>
       <p className="caution-msg">
         ⚠️ Esta versão é otimizada para imagens com <strong>grande número de colônias(&gt;300 UFC/placa)</strong>.
         Pode gerar falsos positivos em placas com baixa densidade ou interferências no fundo.

--- a/frontend/src/components/UploadSection.jsx
+++ b/frontend/src/components/UploadSection.jsx
@@ -2,29 +2,112 @@ import React from 'react';
 
 function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAmostra, processando, mensagemErroUI, resetSignal }) {
   const [previewSrc, setPreviewSrc] = React.useState(null);
+  const [selectedFile, setSelectedFile] = React.useState(null);
+  const [advanced, setAdvanced] = React.useState(false);
+  const [areaMin, setAreaMin] = React.useState(4.0);
+  const [circularidadeMin, setCircularidadeMin] = React.useState(0.30);
+  const [maxSizeFactor, setMaxSizeFactor] = React.useState(0.2);
+  const canvasRef = React.useRef(null);
+  const imgRef = React.useRef(null);
+  const [drawing, setDrawing] = React.useState(false);
+  const [startPt, setStartPt] = React.useState(null);
+  const [circle, setCircle] = React.useState({ x: null, y: null, r: null });
 
   React.useEffect(() => {
     setPreviewSrc(null);
+    setSelectedFile(null);
+    setCircle({ x: null, y: null, r: null });
   }, [resetSignal]);
 
-  const previewAndUpload = (files) => {
+  React.useEffect(() => {
+    if (previewSrc && canvasRef.current && imgRef.current) {
+      const canvas = canvasRef.current;
+      const img = imgRef.current;
+      canvas.width = img.width;
+      canvas.height = img.height;
+    }
+  }, [previewSrc, advanced]);
+
+  const previewFile = (files) => {
     const file = files && files[0];
     if (!file) return;
     const reader = new FileReader();
     reader.onload = (e) => {
       setPreviewSrc(e.target.result);
-      handleImageUpload({ target: { files } });
+      setSelectedFile(file);
     };
     reader.readAsDataURL(file);
   };
 
   const handleFileSelect = (e) => {
-    previewAndUpload(e.target.files);
+    previewFile(e.target.files);
   };
 
   const handleDrop = (e) => {
     e.preventDefault();
-    previewAndUpload(e.dataTransfer.files);
+    previewFile(e.dataTransfer.files);
+  };
+
+  const drawCircle = (x, y, r) => {
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    if (r > 0) {
+      ctx.beginPath();
+      ctx.strokeStyle = 'red';
+      ctx.lineWidth = 2;
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  };
+
+  const handleMouseDown = (e) => {
+    if (!advanced) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setStartPt({ x, y });
+    setDrawing(true);
+  };
+
+  const handleMouseMove = (e) => {
+    if (!drawing) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const r = Math.sqrt(Math.pow(x - startPt.x, 2) + Math.pow(y - startPt.y, 2));
+    drawCircle(startPt.x, startPt.y, r);
+  };
+
+  const handleMouseUp = (e) => {
+    if (!drawing) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const r = Math.sqrt(Math.pow(x - startPt.x, 2) + Math.pow(y - startPt.y, 2));
+    drawCircle(startPt.x, startPt.y, r);
+    setCircle({ x: startPt.x, y: startPt.y, r });
+    setDrawing(false);
+  };
+
+  const handleProcessar = () => {
+    if (!selectedFile) return;
+
+    const extras = {
+      area_min: areaMin,
+      circularidade_min: circularidadeMin,
+      max_colony_size_factor: maxSizeFactor,
+    };
+
+    if (circle.x != null && imgRef.current) {
+      const img = imgRef.current;
+      const scaleX = img.naturalWidth / img.width;
+      const scaleY = img.naturalHeight / img.height;
+      extras.x = Math.round(circle.x * scaleX);
+      extras.y = Math.round(circle.y * scaleY);
+      extras.r = Math.round(circle.r * Math.max(scaleX, scaleY));
+    }
+
+    handleImageUpload(selectedFile, extras);
   };
 
   return (
@@ -58,7 +141,68 @@ function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAm
 
       {previewSrc && (
         <div className="preview-container">
-          <img src={previewSrc} alt="Pré-visualização" className="preview-image" />
+          <div style={{ position: 'relative', display: 'inline-block' }}>
+            <img
+              src={previewSrc}
+              alt="Pré-visualização"
+              className="preview-image"
+              ref={imgRef}
+            />
+            {advanced && (
+              <canvas
+                ref={canvasRef}
+                className="draw-canvas"
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        className="btn"
+        onClick={() => setAdvanced(a => !a)}
+        disabled={processando}
+      >
+        {advanced ? 'Ocultar Avançado' : '⚙️ Análise Avançada'}
+      </button>
+
+      {advanced && (
+        <div className="advanced-options">
+          <p className="draw-hint">Clique no centro da placa e arraste para a borda para definir a ROI.</p>
+          <label>
+            Área mínima <span className="help-icon" title="Tamanho mínimo da colônia em pixels">!</span>:
+            <input
+              type="number"
+              step="0.1"
+              value={areaMin}
+              onChange={e => setAreaMin(e.target.value)}
+              className="text-input"
+            />
+          </label>
+          <label>
+            Circularidade mínima <span className="help-icon" title="0 = formato irregular, 1 = círculo perfeito">!</span>:
+            <input
+              type="number"
+              step="0.01"
+              value={circularidadeMin}
+              onChange={e => setCircularidadeMin(e.target.value)}
+              className="text-input"
+            />
+          </label>
+          <label>
+            Fator máximo do raio <span className="help-icon" title="Limite superior do raio de uma colônia em relação ao raio da placa">!</span>:
+            <input
+              type="number"
+              step="0.01"
+              value={maxSizeFactor}
+              onChange={e => setMaxSizeFactor(e.target.value)}
+              className="text-input"
+            />
+          </label>
         </div>
       )}
 
@@ -69,13 +213,20 @@ function UploadSection({ fileInputRef, handleImageUpload, nomeAmostra, setNomeAm
       )}
 
       {!processando && (
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className="btn"
-          disabled={processando}
-        >
-          📤 Enviar Imagem
-        </button>
+        <>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="btn"
+            disabled={processando}
+          >
+            📁 Selecionar Imagem
+          </button>
+          {selectedFile && (
+            <button onClick={handleProcessar} className="btn" disabled={processando}>
+              🚀 Processar
+            </button>
+          )}
+        </>
       )}
     </>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -270,6 +270,35 @@ button:focus-visible {
 }
 
 .preview-image {
-  max-width: 150px;
+  max-width: 200px;
   border-radius: 8px;
+}
+
+.draw-canvas {
+  position: absolute;
+  left: 0;
+  top: 0;
+  cursor: crosshair;
+}
+
+.advanced-options {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+
+.draw-hint {
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.help-icon {
+  margin-left: 4px;
+  cursor: help;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  padding: 0 4px;
+  font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- aumentar a imagem de pré-visualização e exibir instruções de desenho
- ícones de ajuda para parâmetros `area_min`, `circularidade_min` e `max_colony_size_factor`
- atualizar versões para 1.0.3

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_683fab7ef3008325881d0081fa770cee