### PR TITLE
Implement feedback training capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 
 # Build artifacts
 /dist/
+/frontend/dist/
+frontend/package-lock.json
 /build/
 *.log
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contador-colonias",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import UploadSection from './components/UploadSection';
 import ProgressBar from './components/ProgressBar';
 import ResultSection from './components/ResultSection';
 import HistorySection from './components/HistorySection';
+import TrainingModal from './components/TrainingModal';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -21,6 +22,8 @@ function App() {
   const [todosSelecionados, setTodosSelecionados] = useState(false);
   const [mensagemErroUI, setMensagemErroUI] = useState("");
   const [uploadResetSignal, setUploadResetSignal] = useState(0);
+  const [feedbackToken, setFeedbackToken] = useState(null);
+  const [mostrarTreino, setMostrarTreino] = useState(false);
 
   const xhrRef = useRef(null);
 
@@ -76,6 +79,8 @@ function App() {
       xhrRef.current.abort();
     }
     setUploadResetSignal((c) => c + 1);
+    setFeedbackToken(null);
+    setMostrarTreino(false);
   };
 
   const handleImageUpload = async (file, extras = {}) => {
@@ -152,6 +157,10 @@ function App() {
             dadosFeedback[key] = valor;
           }
         });
+
+        if (headers["x-feedback-token"]) {
+          setFeedbackToken(headers["x-feedback-token"]);
+        }
 
         setResultado(resumo);
         setFeedback(dadosFeedback);
@@ -312,7 +321,12 @@ function App() {
         feedback={feedback}
         onBaixar={baixarImagem}
         onReset={handleReset}
+        onTreinar={() => setMostrarTreino(true)}
       />
+
+      {mostrarTreino && (
+        <TrainingModal token={feedbackToken} onClose={() => setMostrarTreino(false)} />
+      )}
 
       <HistorySection
         logAnalises={logAnalises}

--- a/frontend/src/components/ResultSection.jsx
+++ b/frontend/src/components/ResultSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function ResultSection({ imagem, processando, resultado, feedback, onBaixar, onReset }) {
+function ResultSection({ imagem, processando, resultado, feedback, onBaixar, onReset, onTreinar }) {
   if (!imagem) return null;
 
   const total = parseInt(resultado.TOTAL || 0);
@@ -37,6 +37,9 @@ function ResultSection({ imagem, processando, resultado, feedback, onBaixar, onR
             </button>
             <button onClick={onReset} className="btn" disabled={processando}>
               ♻️ Nova Imagem
+            </button>
+            <button onClick={onTreinar} className="btn" disabled={processando}>
+              🤖 Me ajude a treinar a IA
             </button>
           </div>
         </div>

--- a/frontend/src/components/TrainingModal.jsx
+++ b/frontend/src/components/TrainingModal.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+
+const API_URL = import.meta.env.VITE_API_URL;
+const CORES = ['amarela', 'bege', 'clara', 'rosada'];
+
+function TrainingModal({ token, onClose }) {
+  const [dados, setDados] = useState([]);
+  const [labels, setLabels] = useState([]);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${API_URL}/colony_data/${token}`)
+      .then(res => res.ok ? res.json() : Promise.reject(res.statusText))
+      .then(data => {
+        setDados(data.data || []);
+        setLabels((data.data || []).map(d => d.pred));
+      })
+      .catch(() => {});
+  }, [token]);
+
+  const handleChange = (idx, value) => {
+    setLabels(prev => {
+      const copy = [...prev];
+      copy[idx] = value;
+      return copy;
+    });
+  };
+
+  const handleSubmit = () => {
+    const corrections = labels.map((lab, idx) => ({ index: idx, label: lab }));
+    fetch(`${API_URL}/feedback_treinamento`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, corrections })
+    }).then(() => onClose());
+  };
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h3>🤖 Me ajude a treinar a IA</h3>
+        <ul>
+          {dados.map((item, idx) => (
+            <li key={idx} className="feedback-item">
+              Colônia {idx + 1} - Modelo: {item.pred}
+              <select value={labels[idx]} onChange={e => handleChange(idx, e.target.value)}>
+                {CORES.map(c => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            </li>
+          ))}
+        </ul>
+        <button onClick={handleSubmit} className="btn">Enviar Minhas Sugestões</button>
+        <button onClick={onClose} className="btn">Fechar</button>
+      </div>
+    </div>
+  );
+}
+
+export default TrainingModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -302,3 +302,29 @@ button:focus-visible {
   padding: 0 4px;
   font-weight: bold;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  color: #000;
+  padding: 20px;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.feedback-item {
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary
- bump version
- add endpoints for feedback data and training ingestion
- store feedback token in frontend and show TrainModal
- allow user to review colors and send corrections
- style modal for training overlay

## Testing
- `npm install`
- `npm run build`
- `pytest` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_683fbbf134588325aa6ee4d1bd0e388c