### PR TITLE
Adiciona log HSV e bump para 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,16 @@ pip install fastapi uvicorn opencv-python-headless numpy scipy python-multipart 
 
 ## 🏋️ Treinar Modelo de Cor
 
-Forneça um CSV com as colunas `h`, `s`, `v` e `label` (uma das quatro cores).
+Forneça um CSV inicial com as colunas `h`, `s`, `v` e `label`.
+Você pode complementar esse conjunto com os valores de HSV gerados nas análises.
+Esses dados são gravados em `backend/analysis_hsv_log.csv` e as correções
+enviadas pelo endpoint `/feedback_treinamento` ficam em
+`backend/feedback_data.csv`.
+
 Execute:
 
 ```bash
-python scripts/train_color_model.py dados.csv backend/color_model.pkl
+python scripts/train_color_model.py dados.csv backend/color_model.pkl --include-backend-data
 ```
 
 O arquivo `color_model.pkl` será carregado automaticamente pelo backend.
@@ -111,12 +116,10 @@ The frontend reads this variable using `import.meta.env.VITE_API_URL` to send re
 
 ## 📌 Update Notes
 
-### Version 1.6.7 (UI + API)
+### Version 1.7.0 (UI + API)
 
-*Refined Calculation Logic: Significantly improved accuracy and robustness of density and total colony estimation by correcting and detailing the area extrapolation methodology.
-*Optimized Logging: Essential operational logs maintained for monitoring, while verbose debug logs have been cleaned up post-resolution of calculation issues.
-*New Feedback Header: Introduced X-Feedback-Filtradas-Tamanho-Maximo to provide insight into colonies filtered due to excessive size relative to the Petri dish.
-*Consistent use of specific internal variable names (e.g., r_detectado_placa, r_margem_calculada) for improved code clarity and maintenance.
+*Novo log automático de HSV de cada análise para facilitar o re-treinamento do modelo.
+*Script de treinamento atualizado com opção `--include-backend-data` para usar esses logs e as correções de feedback.
 
 ## 🔮 Future Work
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contador-colonias",
-  "version": "1.0.4",
+  "version": "1.7.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/scripts/train_color_model.py
+++ b/scripts/train_color_model.py
@@ -8,9 +8,22 @@ def main():
     parser = argparse.ArgumentParser(description="Treina modelo de classificação de cor")
     parser.add_argument("csv", help="Arquivo CSV com colunas h,s,v,label")
     parser.add_argument("saida", help="Arquivo para salvar o modelo treinado")
+    parser.add_argument(
+        "--include-backend-data",
+        action="store_true",
+        help="Inclui dados de HSV gerados pelo backend (analysis_hsv_log.csv e feedback_data.csv)",
+    )
     args = parser.parse_args()
 
     dados = pd.read_csv(args.csv)
+    if args.include_backend_data:
+        for extra in ["backend/analysis_hsv_log.csv", "backend/feedback_data.csv"]:
+            try:
+                df_extra = pd.read_csv(extra)
+                dados = pd.concat([dados, df_extra], ignore_index=True)
+            except FileNotFoundError:
+                continue
+        dados = dados.drop_duplicates()
     X = dados[["h", "s", "v"]]
     y = dados["label"]
 


### PR DESCRIPTION
## Summary
- version bump para 1.7.0
- registrar HSV de cada análise em `analysis_hsv_log.csv`
- script de treinamento aceita `--include-backend-data`
- instruções atualizadas no README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pandas scikit-learn joblib`
- `python scripts/train_color_model.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68406c6cc4348325944b72a71aed3d6b