### PR TITLE
Implementa modo de feedback sequencial

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -465,10 +465,20 @@ async def feedback_treinamento(payload: FeedbackPayload):
     if dados is None:
         raise HTTPException(status_code=404, detail="Token inválido")
     linhas = []
+    hora_brasilia = datetime.now(timezone.utc) - timedelta(hours=3)
+    data_str = hora_brasilia.strftime("%Y-%m-%d")
+    hora_str = hora_brasilia.strftime("%H:%M:%S")
     for item in payload.corrections:
         if 0 <= item.index < len(dados):
             row = dados[item.index]
-            linhas.append({"h": row["h"], "s": row["s"], "v": row["v"], "label": item.label})
+            linhas.append({
+                "h": row["h"],
+                "s": row["s"],
+                "v": row["v"],
+                "label": item.label,
+                "data": data_str,
+                "hora": hora_str,
+            })
     if not linhas:
         raise HTTPException(status_code=400, detail="Nenhuma correção válida")
     csv_path = os.path.join(os.path.dirname(__file__), "feedback_data.csv")

--- a/frontend/src/components/TrainingModal.jsx
+++ b/frontend/src/components/TrainingModal.jsx
@@ -5,54 +5,99 @@ const CORES = ['amarela', 'bege', 'clara', 'rosada'];
 
 function TrainingModal({ token, onClose }) {
   const [dados, setDados] = useState([]);
-  const [labels, setLabels] = useState([]);
+  const [indice, setIndice] = useState(0);
+  const [corEscolhida, setCorEscolhida] = useState('');
+  const [correcoes, setCorrecoes] = useState([]);
+  const [simCount, setSimCount] = useState(0);
+  const [modoSelecao, setModoSelecao] = useState(false);
+  const [agradecimento, setAgradecimento] = useState(false);
 
   useEffect(() => {
     if (!token) return;
     fetch(`${API_URL}/colony_data/${token}`)
-      .then(res => res.ok ? res.json() : Promise.reject(res.statusText))
+      .then(res => (res.ok ? res.json() : Promise.reject(res.statusText)))
       .then(data => {
         setDados(data.data || []);
-        setLabels((data.data || []).map(d => d.pred));
       })
       .catch(() => {});
   }, [token]);
 
-  const handleChange = (idx, value) => {
-    setLabels(prev => {
-      const copy = [...prev];
-      copy[idx] = value;
-      return copy;
-    });
+  const avancarIndice = () => {
+    setModoSelecao(false);
+    setIndice((prev) => prev + 1);
   };
 
-  const handleSubmit = () => {
-    const corrections = labels.map((lab, idx) => ({ index: idx, label: lab }));
+  const enviarFeedback = (linhas) => {
+    if (linhas.length === 0) {
+      setAgradecimento(true);
+      return;
+    }
     fetch(`${API_URL}/feedback_treinamento`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token, corrections })
-    }).then(() => onClose());
+      body: JSON.stringify({ token, corrections: linhas })
+    }).then(() => setAgradecimento(true));
   };
+
+  const handleNao = () => {
+    if (indice >= dados.length - 1) {
+      enviarFeedback(correcoes);
+    } else {
+      avancarIndice();
+    }
+  };
+
+  const handleSim = () => {
+    setCorEscolhida(dados[indice].pred);
+    setModoSelecao(true);
+  };
+
+  const confirmarCor = () => {
+    const nova = [...correcoes, { index: indice, label: corEscolhida }];
+    const totalSim = simCount + 1;
+    setCorrecoes(nova);
+    setSimCount(totalSim);
+    if (totalSim >= 3 || indice >= dados.length - 1) {
+      enviarFeedback(nova);
+    } else {
+      avancarIndice();
+    }
+  };
+
+  if (agradecimento) {
+    return (
+      <div className="modal">
+        <div className="modal-content">
+          <p>Obrigado por colaborar!</p>
+          <button onClick={onClose} className="btn">Fechar</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!dados[indice]) return null;
 
   return (
     <div className="modal">
       <div className="modal-content">
         <h3>🤖 Me ajude a treinar a IA</h3>
-        <ul>
-          {dados.map((item, idx) => (
-            <li key={idx} className="feedback-item">
-              Colônia {idx + 1} - Modelo: {item.pred}
-              <select value={labels[idx]} onChange={e => handleChange(idx, e.target.value)}>
-                {CORES.map(c => (
-                  <option key={c} value={c}>{c}</option>
-                ))}
-              </select>
-            </li>
-          ))}
-        </ul>
-        <button onClick={handleSubmit} className="btn">Enviar Minhas Sugestões</button>
-        <button onClick={onClose} className="btn">Fechar</button>
+        {!modoSelecao ? (
+          <div>
+            <p>Esta região detectada é uma colônia? (Previsto: {dados[indice].pred})</p>
+            <button onClick={handleSim} className="btn">Sim</button>
+            <button onClick={handleNao} className="btn">Não</button>
+          </div>
+        ) : (
+          <div>
+            <p>Qual a cor correta?</p>
+            <select value={corEscolhida} onChange={e => setCorEscolhida(e.target.value)}>
+              {CORES.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <button onClick={confirmarCor} className="btn">Confirmar</button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- altera `TrainingModal` para coletar até 3 confirmações sequenciais de colônias
- adiciona salvamento de data e hora no `feedback_treinamento`

## Testing
- `python -m py_compile backend/main.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840e204c0ec83259fc26ce138a1169b